### PR TITLE
Display the connector class on the new connectors page

### DIFF
--- a/src/kafka-connect/select-type/sink-or-source.html
+++ b/src/kafka-connect/select-type/sink-or-source.html
@@ -31,7 +31,12 @@
                         <img ng-src="src/assets/icons/{{source.icon}}" class="md-avatar" style="height: initial;"/>
                         <div class="md-list-item-text" >
                             <h3><b>{{source.name}}</b></h3>
-                            <p style="font-size:12px;">{{source.description}}</p>
+                            <p style="font-size:12px;">
+                                {{source.description}}
+                            </p>
+                            <p style="font-size:10px;">
+                                class: {{source.class}}
+                            </p>
                         </div>
                     </md-list-item>
                 </md-list>
@@ -45,7 +50,12 @@
                         <img ng-src="src/assets/icons/{{sink.icon}}" class="md-avatar" style="width:40px;height:40px;" />
                         <div class="md-list-item-text">
                             <h3><b>{{sink.name}}</b></h3>
-                            <p style="font-size:12px;">{{sink.description}}</p>
+                            <p style="font-size:12px;">
+                                {{sink.description}}
+                            </p>
+                            <p style="font-size:10px;">
+                                class: {{sink.class}}
+                            </p>
                         </div>
                     </md-list-item>
                 </md-list>


### PR DESCRIPTION
Display the connector class name on the new connector page as requested in #33 

Example:
<img width="391" alt="screen shot 2017-10-22 at 2 49 41 pm" src="https://user-images.githubusercontent.com/6844803/31865179-59844144-b738-11e7-8b69-01d6e12a8aaf.png">
