### PR TITLE
Replace "hints" button with documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,20 @@ Additionally you can assign custom names to your Connect clusters by appending a
 
 ```"CONNECT_URL=http://connect.1.url;dev cluster,http://connect.2.url;production cluster"```
  
-Web UI will be available at `http://localhost:8000`
+Web UI will be available at [localhost:8000](http://localhost:8000/)
 
 
 ## Build from source
 
 ```
-    git clone https://github.com/Landoop/kafka-connect-ui.git
-    cd kafka-connect-ui
-    npm install -g bower
-    npm install -g http-server
-    npm install
-    bower install
-    http-server -p 8080 .
+git clone https://github.com/Landoop/kafka-connect-ui.git
+cd kafka-connect-ui
+npm install -g bower http-server
+npm install
+http-server -p 8080 .
 ```
-Web UI will be available at `http://localhost:8080`
+
+Web UI will be available at [localhost:8080](http://localhost:8080/)
 
 ### Nginx config
 

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "kafka connect"
   ],
   "author": "Landoop team",
-  "license": "BSL",
+  "license": "BSL-1.0",
   "bugs": {
     "url": "https://github.com/Landoop/kafka-connect-ui/issues"
   },

--- a/src/kafka-connect/create-connector/create-connector.controller.js
+++ b/src/kafka-connect/create-connector/create-connector.controller.js
@@ -22,7 +22,6 @@ angularAPP.controller('CreateConnectorCtrl', function ($scope, $rootScope, $http
 
   $scope.prefillValues = true;
   $scope.showCurl = false;
-  $scope.docs = '';
   $scope.toggleShowCurl = function () { $scope.showCurl = !$scope.showCurl; };
 
   $scope.nextTab = function() { $scope.selectedTabIndex = ($scope.selectedTabIndex == $scope.maxNumberOfTabs) ? 0 : $scope.selectedTabIndex + 1; };

--- a/src/kafka-connect/create-connector/create-connector.controller.js
+++ b/src/kafka-connect/create-connector/create-connector.controller.js
@@ -22,7 +22,6 @@ angularAPP.controller('CreateConnectorCtrl', function ($scope, $rootScope, $http
 
   $scope.prefillValues = true;
   $scope.showCurl = false;
-  $scope.showDocumentation = false;
   $scope.docs = '';
   $scope.toggleShowCurl = function () { $scope.showCurl = !$scope.showCurl; };
 
@@ -231,9 +230,7 @@ angularAPP.controller('CreateConnectorCtrl', function ($scope, $rootScope, $http
      angular.forEach(supportedConnectorsTemplates, function (template) {
         if (template.class == pluginClass) {
             connectorIcon = template.icon;
-            $http.get('src/documentation/' + template.docs).then(function(response){
-                $scope.docs = response.data;
-            });
+            $scope.docs = template.docs;
         }
      });
 
@@ -330,10 +327,6 @@ $scope.getAllConfig = function (pluginClass){
     }
     $scope.showAllConfig = false;
   }
-}
-
-$scope.showConnectorDocumentation = function(pluginClass) {
-    $scope.showDocumentation = !$scope.showDocumentation;
 }
 
 });

--- a/src/kafka-connect/create-connector/create-connector.html
+++ b/src/kafka-connect/create-connector/create-connector.html
@@ -27,8 +27,8 @@
                         <p style="font-size:12px;padding:0px; margin:0px">{{connector.description}}</p>
                         <p style="font-size:12px;padding:0px; margin:5px 0 0 0;" class="grey">
                             <span ng-bind="::connector.class"></span>
-                            <span ng-if="docs">
-                                | <a ng-href="{{ docs }}" target="_blank">docs</a>
+                            <span ng-if="::docs">
+                                | <a ng-href="{{:: docs }}" target="_blank">docs</a>
                             </span>
                         </p>
                     </div>

--- a/src/kafka-connect/create-connector/create-connector.html
+++ b/src/kafka-connect/create-connector/create-connector.html
@@ -25,17 +25,19 @@
                         <h3 ng-show="connector.type!='Sink'" style="font-size:12px;padding:0px; margin:0px">{{simpleName(connector.name)}} <i class="fa fa-long-arrow-right" aria-hidden="true"></i> Kafka</h3>
                         <h3 ng-show="connector.type=='Sink'" style="font-size:12px;padding:0px; margin:0px"> Kafka <i class="fa fa-long-arrow-right" aria-hidden="true"></i> {{simpleName(connector.name)}} </h3>
                         <p style="font-size:12px;padding:0px; margin:0px">{{connector.description}}</p>
-                        <p style="font-size:12px;padding:0px; margin:5px 0 0 0;" class="grey">class: {{connector.class}}</p>
+                        <p style="font-size:12px;padding:0px; margin:5px 0 0 0;" class="grey">
+                            <span ng-bind="::connector.class"></span>
+                            <span ng-if="docs">
+                                | <a ng-href="{{ docs }}" target="_blank">docs</a>
+                            </span>
+                        </p>
                     </div>
                     <span flex></span>
-                    <md-button ng-click="showConnectorDocumentation(connector.class)" layout-align="right" aria-label="Show connector docs" style="padding-top:2px;padding-bottom:2px">
-                        Hints
-                    </md-button>
                 </div>
             </div>
 
             <!-- Either show the configuration - or documentation -->
-            <md-card-content ng-hide="showDocumentation" style="padding-top: 2px">
+            <md-card-content style="padding-top: 2px">
                 <!--Show Property file-->
                 <div id="propertyFile" ng-hide="showCurl"
                      ng-model-options="{ debounce: 500 }"
@@ -105,12 +107,6 @@
                     </div>
                 </div>
             </md-card-content>
-
-            <md-card-content ng-show="showDocumentation" style="padding-top: 2px">
-                <div ng-bind-html="docs | html"></div>
-            </md-card-content>
-
-
         </md-card>
     </div>
 </div>


### PR DESCRIPTION
I noticed the "hints" button when creating connectors does not seem to work anymore. It seems the [documentation partials](https://github.com/Landoop/kafka-connect-ui/tree/master/src/documentation) have been replaced with links?

This replaces the "hints" button with a link to the documentation:

<img width="959" alt="screen shot 2018-01-20 at 12 39 00 pm" src="https://user-images.githubusercontent.com/847532/35186240-06c39eda-fddf-11e7-8cc2-0762cb304f96.png">

similar to how this is handled in the list of connectors.

I'm unsure if the documentation partials themselves should be removed. 