### PR TITLE
Fix #69 Cannot parse automatically the right configurations in PROPERTIES mode when we create a new connector

### DIFF
--- a/src/kafka-connect/configuration/editor/configuration-editor-properties.component.js
+++ b/src/kafka-connect/configuration/editor/configuration-editor-properties.component.js
@@ -61,7 +61,8 @@
         var line;
         var lines = value.match(/[^\r\n]+/g);
 
-        for (var i in lines) {
+        var lines_len = lines.length;
+        for (var i = 0; i < lines_len; i++) {
           line = lines[i].trim();
 
           if (!line || '#' === line.charAt(0)) {

--- a/src/kafka-connect/configuration/editor/configuration-editor.html
+++ b/src/kafka-connect/configuration/editor/configuration-editor.html
@@ -1,10 +1,12 @@
 <md-tabs md-dynamic-height>
   <md-tab label="Properties">
-    <configuration-editor-properties
-      ng-change="$ctrl.onModelChange()"
-      ng-model="$ctrl.model"
-      ng-readonly="$ctrl.ngReadonly">
-    </configuration-editor-properties>
+    <md-tab-body>
+      <configuration-editor-properties
+        ng-change="$ctrl.onModelChange()"
+        ng-model="$ctrl.model"
+        ng-readonly="$ctrl.ngReadonly">
+      </configuration-editor-properties>
+    </md-tab-body>
   </md-tab>
   <md-tab label="JSON">
     <configuration-editor-json

--- a/src/kafka-connect/configuration/editor/configuration-editor.html
+++ b/src/kafka-connect/configuration/editor/configuration-editor.html
@@ -1,12 +1,10 @@
 <md-tabs md-dynamic-height>
   <md-tab label="Properties">
-    <md-tab-body>
-      <configuration-editor-properties
-        ng-change="$ctrl.onModelChange()"
-        ng-model="$ctrl.model"
-        ng-readonly="$ctrl.ngReadonly">
-      </configuration-editor-properties>
-    </md-tab-body>
+    <configuration-editor-properties
+      ng-change="$ctrl.onModelChange()"
+      ng-model="$ctrl.model"
+      ng-readonly="$ctrl.ngReadonly">
+    </configuration-editor-properties>
   </md-tab>
   <md-tab label="JSON">
     <configuration-editor-json


### PR DESCRIPTION
Fix #69 Cannot parse automatically the right configurations in `PROPERTIES` mode when we create a new connector

![image](https://user-images.githubusercontent.com/8108788/37329228-df28c4e6-26d7-11e8-9243-f5dbca205e54.png)

![image](https://user-images.githubusercontent.com/8108788/37329588-5ee5b120-26d9-11e8-9043-b4e242ca0f89.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/landoop/kafka-connect-ui/70)
<!-- Reviewable:end -->
